### PR TITLE
Finish explaining why rel="preconnect" is important

### DIFF
--- a/README.md
+++ b/README.md
@@ -311,7 +311,7 @@ List of the tools you can use to test or monitor your website or application:
     ```
 
     *Why:*
-    > When you arrived on a website, your device needs to find out where your site lives and which server it needs to connect with. Your browser had to contact a DNS server and wait for the lookup complete before fetching the resource (fonts, CSS files...). Prefetches and preconnects allow the browser
+    > When you arrived on a website, your device needs to find out where your site lives and which server it needs to connect with. Your browser had to contact a DNS server and wait for the lookup complete before fetching the resource (fonts, CSS files...). Prefetches and preconnects allow the browser to lookup the DNS information and start establising a TCP connection to the server hosting the font file. This provides a performance boost because by the time the browser gets around to parsing the css file with the font information and discovering it needs to request a font file from the server, it will already have pre-resolved the DNS information and have an open connection to the server ready in its connection pool.
 
     *How:*
     > ⁃ Before prefetching your webfonts, use webpagetest to evaluate your website <br>


### PR DESCRIPTION
The existing "Why" section recommending `preconnect` for fonts appears to be incomplete. I've attempted to add some additional information to complete the though.