### PR TITLE
Delete Logo Link README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <h1 align="center">
 <br>
-  <img src="https://raw.githubusercontent.com/thedaviddias/Front-End-Performance-Checklist/master/images/logo-front-end-performance-checklist.jpg" alt="Front-End Performance Checklist" width="170">
+  <a href="#none"><img src="https://raw.githubusercontent.com/thedaviddias/Front-End-Performance-Checklist/master/images/logo-front-end-performance-checklist.jpg" alt="Front-End Performance Checklist" width="170"></a>
   <br>
     <br>
   Front-End Performance Checklist


### PR DESCRIPTION
Signed-off-by: clucle <wjdenwls123@gmail.com>

**Fixes**: #62 

#### Short description of what this resolves:
delete link at logo image

#### Proposed changes:
when click image, popup not using page. so delete link

#### Commnet

I said that in the issue 62 deleted links images

```Can I open PR for making the images (logo or low, medium, ...) non-clickable?```

It seems that the request was not delivered well.

So I send pr again only delete the logo image😄
