### PR TITLE
Adds Google's Web.dev Tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ List of the tools you can use to test or monitor your website or application:
  * 🛠 [Treo: Page Speed Monitoring](https://treo.sh/?ref=perfchecklist)
  * 🛠 [GTmetrix | Website Speed and Performance Optimization](https://gtmetrix.com/)
  * 🛠 [PageSpeed Insights](https://developers.google.com/speed/pagespeed/insights/)
+ * 🛠 [Web.dev](https://web.dev/measure)
  * 🛠 [Pingdom Website Speed Test](https://tools.pingdom.com)
  * 📖 [Make the Web Faster | Google Developers](https://developers.google.com/speed/)
  * 🛠 [Sitespeed.io - Welcome to the wonderful world of Web Performance](https://www.sitespeed.io/)


### PR DESCRIPTION
Adding Web.dev to Performance tools list. It runs all the audits of LightHouse tool. In comparison, PageSpeed Insights only runs the Performance audit