### PR TITLE
Replace packtracker with Gravity

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ List of the tools you can use to test or monitor your website or application:
 - 🛠 [Yellow Lab Tools | Online test to help speeding up heavy web pages](https://yellowlab.tools/)
 - 🛠 [Speedrank - Web Performance Monitoring](https://speedrank.app/)
 - 🛠 [DebugBear - Monitor website performance and Lighthouse scores](https://www.debugbear.com/)
-- 🛠 [packtracker.io - Check your webpack bundle size on every pull request.](https://packtracker.io/)
+- 🛠 [Gravity CI - Check your build artifacts sizes on every pull request.](https://gravity.ci/)
 - 🛠 [Exthouse - Analyze the impact of a browser extension on web performance](https://github.com/treosh/exthouse)
 - 🛠 [LogRocket - Measure front-end performance in production apps](https://logrocket.com)
 


### PR DESCRIPTION
<!-- Love Front-End Checklist? Please consider supporting our collective:
👉  https://opencollective.com/front-end-checklist/donate -->

**Fixes**: #

🚨 Please review the [guidelines for contributing](../CONTRIBUTING.md) and our [code of conduct](../CODE_OF_CONDUCT.md) to this repository. 🚨
**Please complete these steps and check these boxes (by putting an x inside the brackets) before filing your PR:**

- [x] Check the commit's or even all commits' message styles matches our requested structure.
- [x] Check your code additions will fail neither code linting checks nor unit test.

#### Short description of what this resolves:

packtracker.io seems to be dead, this replaces it with Gravity which is a very similar tool: https://gravity.ci/

#### Proposed changes:

- remove the (dead) link to packtracker.io
- add link to Gravity as a replacement

👍 Thank you!
